### PR TITLE
Add responsive CV page with custom styling

### DIFF
--- a/cv.css
+++ b/cv.css
@@ -1,0 +1,108 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(135deg, #f0f4f8, #d9e2ec);
+  color: #2c3e50;
+  line-height: 1.6;
+}
+
+.cv-container {
+  max-width: 1200px;
+  margin: 40px auto;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+  overflow: hidden;
+}
+
+.header {
+  text-align: center;
+  padding: 40px 20px;
+  background: #34495e;
+  color: #ecf0f1;
+}
+
+.header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+}
+
+.location {
+  font-weight: 300;
+  margin-bottom: 20px;
+}
+
+.tagline {
+  max-width: 900px;
+  margin: 0 auto 20px;
+}
+
+.links a {
+  color: #f1c40f;
+  text-decoration: none;
+  margin: 0 10px;
+  font-weight: 600;
+}
+
+.links a:hover {
+  text-decoration: underline;
+}
+
+.main {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 40px;
+  gap: 40px;
+}
+
+.primary {
+  flex: 2 1 600px;
+}
+
+.sidebar {
+  flex: 1 1 300px;
+  background: #f8f9fa;
+  padding: 20px;
+  border-radius: 8px;
+  height: fit-content;
+}
+
+h2 {
+  color: #e74c3c;
+  margin-bottom: 10px;
+  border-bottom: 2px solid #e74c3c;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.job, .edu {
+  margin-bottom: 20px;
+}
+
+.job-meta {
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
+ul {
+  margin-left: 20px;
+}
+
+.skills li {
+  margin-bottom: 10px;
+}
+
+@media (max-width: 768px) {
+  .main {
+    flex-direction: column;
+  }
+  .sidebar {
+    order: -1;
+  }
+}

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CV - Ankush Gaharwar</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="cv.css">
+</head>
+<body>
+  <div class="cv-container">
+    <header class="header">
+      <h1>Ankush Gaharwar</h1>
+      <p class="location">Rome, Italy · +39 3519497594</p>
+      <p class="tagline">Collaborative UX/UI designer with Microsoft and Unilever experience, passionate about turning concepts into polished digital products. Eager to understand user preferences and craft seamless web and mobile interfaces. Recipient of the 2024 Adobe Experience Award.</p>
+      <p class="links">
+        <a href="https://linkedin.com/in/ankushgaharwar" target="_blank">LinkedIn</a>
+        <a href="https://ankushgaharwar.github.io/" target="_blank">Portfolio</a>
+        <a href="mailto:ankushgaharwar@gmail.com">ankushgaharwar@gmail.com</a>
+      </p>
+    </header>
+    <main class="main">
+      <section class="primary">
+        <h2>Experience</h2>
+        <div class="job">
+          <h3>Artificial Intelligence Risk, Inc — UX UI Specialist</h3>
+          <p class="job-meta">Rome, Italy · July 2024 - Present</p>
+          <ul>
+            <li>Sole designer responsible for creating and developing intuitive user interfaces for AI-driven risk management systems, ensuring seamless usability and performance.</li>
+            <li>Conducted user research and usability testing to align product design with client needs.</li>
+            <li>Collaborated with developers and data scientists to integrate AI workflows into responsive designs.</li>
+            <li>Delivered high-quality front-end development using Figma and HTML/CSS.</li>
+            <li>Managed product delivery by creating, prioritizing, and assigning tickets to developers.</li>
+          </ul>
+        </div>
+        <div class="job">
+          <h3>Unilever — Mid UI/UX Designer</h3>
+          <p class="job-meta">Rome, Italy · April 2022 - June 2024</p>
+          <ul>
+            <li>Designed user-centric interfaces for Gro24*7 U-Smile and Compre Ahora's web and mobile applications, customizing them for diverse regional markets in APAC and LATAM to boost user engagement.</li>
+            <li>Conducted over 200 hours of user testing to refine the user experience across a suite of mobile applications, resulting in a 35% increase in user retention and a 25% improvement in customer satisfaction ratings.</li>
+            <li>Enhanced user experience for Gro24*7 U-Smile and Compre Ahora's web and mobile applications through tailored designs for APAC and LATAM markets, leading to a 35% increase in user retention and a 25% improvement in customer satisfaction ratings.</li>
+          </ul>
+        </div>
+        <div class="job">
+          <h3>Microsoft — UI/UX Designer</h3>
+          <p class="job-meta">Bengaluru, India · August 2020 - December 2021</p>
+          <ul>
+            <li>Led comprehensive reviews of existing user journeys and identified gaps, improving overall design strategy.</li>
+            <li>Collaborated closely with product teams, ensuring research findings were translated into actionable design solutions that aligned with business goals.</li>
+            <li>Ensured all designs are accessible and inclusive, adhering to strict accessibility standards.</li>
+          </ul>
+        </div>
+        <div class="job">
+          <h3>Uber — UI/UX Designer</h3>
+          <p class="job-meta">Bengaluru, India · August 2018 - August 2020</p>
+          <ul>
+            <li>Used both quantitative and qualitative data to solve problems.</li>
+            <li>Responsible for user research, information architecture, interaction and visual design, prototyping, and user testing across web and mobile products.</li>
+            <li>Collaborated with product managers, business partners, and engineers to define product requirements and roadmap, achieving a 30% improvement in project delivery timelines.</li>
+          </ul>
+        </div>
+
+        <h2>Education</h2>
+        <div class="edu">
+          <h3>Sapienza University of Rome — Master of Science in Product and Service Design</h3>
+          <p class="job-meta">Rome, Italy · 2021 - 2023</p>
+          <p>Thesis - VR based furniture design in Zero-Gravity Environments</p>
+        </div>
+        <div class="edu">
+          <h3>SRM University — Bachelor of Computer Application</h3>
+          <p class="job-meta">Chennai, India · 2017 - 2020</p>
+          <p>Final Year Project - Educational Game (Unity 3D)</p>
+        </div>
+
+        <h2>Research</h2>
+        <p><strong>COSMIC KAKSH - VR-based furniture design in Zero-Gravity Environment</strong> — Presented for Master’s Thesis, Master of Product and Service Design, Sapienza University, 2023</p>
+        <p><a href="https://archive.org/details/cosmic-kaksh-report-ankush-gaharwar" target="_blank">Project Report</a></p>
+
+        <h2>Co-Curricular Activities</h2>
+        <ul>
+          <li><strong>Chennai Makerspace, Chennai, India:</strong> Organized robotics and 3D printing workshops, maintained equipment, guided newcomers, and contributed to community projects, fostering a creative and inclusive environment.</li>
+          <li><strong>College President - SRM University, Chennai, India:</strong> Organized cultural programs, led fundraising events, and managed volunteer teams, fostering college community relations and enhancing the institution's social impact.</li>
+          <li><strong>FABLAB Sapienza - Rome, Italy:</strong> Helped with creating 3D prints, CNC cutting and laser cuts.</li>
+          <li><strong>Villa Medici - Rome, Italy:</strong> Helped in making and installing an art for the Cabanes Night 2023 on behalf of Sapienza students.</li>
+          <li><strong>Festival del Verde e del Paesaggio - Rome, Italy:</strong> Made an 8-floor tensegrity structure at the festival with The Community Builders Project and won a jury award.</li>
+        </ul>
+      </section>
+      <aside class="sidebar">
+        <h2>Skills</h2>
+        <ul class="skills">
+          <li><strong>UI/UX Design Principles:</strong> Wireframing, prototyping, user flows, interaction design, visual design</li>
+          <li><strong>Figma Mastery:</strong> High-fidelity mockups, component libraries, and interactive prototypes</li>
+          <li><strong>Multi-Channel Expertise:</strong> Consistent cross-platform design (web, iOS, Android, desktop)</li>
+          <li><strong>User Research & Testing:</strong> Personas, usability testing, A/B testing, and iterative improvements</li>
+          <li><strong>Design Systems & Libraries:</strong> Modular, scalable design systems for rapid development</li>
+          <li><strong>Front-End Knowledge:</strong> HTML, Angular, elasticCMS, collaboration with dev teams</li>
+          <li><strong>Agile Methodology:</strong> Iterative design, sprint planning, stand-ups, retrospectives</li>
+          <li><strong>Collaboration & Stakeholder Management:</strong> Effective communication, requirements gathering, alignment with business goals</li>
+          <li><strong>3D:</strong> Rhino 3D, Grasshopper, Fusion 360, Blender, Rendering, CAD</li>
+          <li><strong>Graphic:</strong> Adobe Photoshop, Adobe Illustrator for visual and interface design</li>
+          <li><strong>Web Development:</strong> HTML, CSS, JavaScript, React, Angular. Back-End Development: Familiarity with PHP. Framer, Webflow, WordPress</li>
+          <li><strong>Game Engines:</strong> Unity3D, Unreal Engine</li>
+        </ul>
+      </aside>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `cv.html` with contact details, experience, education, research, activities and skills
- add `cv.css` for modern two-column layout and responsive styling

## Testing
- `npx htmlhint cv.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac52895b1c8333b730d6430cb66a50