### PR TITLE
Add experimental draggable canvas page

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -110,6 +110,15 @@
       scrollTop = outer.scrollTop;
     });
 
+    outer.addEventListener('touchstart', (e) => {
+      isDown = true;
+      outer.classList.add('dragging');
+      startX = e.touches[0].pageX - outer.offsetLeft;
+      startY = e.touches[0].pageY - outer.offsetTop;
+      scrollLeft = outer.scrollLeft;
+      scrollTop = outer.scrollTop;
+    });
+
     outer.addEventListener('mouseleave', () => {
       isDown = false;
       outer.classList.remove('dragging');
@@ -120,11 +129,27 @@
       outer.classList.remove('dragging');
     });
 
+    outer.addEventListener('touchend', () => {
+      isDown = false;
+      outer.classList.remove('dragging');
+    });
+
     outer.addEventListener('mousemove', (e) => {
       if (!isDown) return;
       e.preventDefault();
       const x = e.pageX - outer.offsetLeft;
       const y = e.pageY - outer.offsetTop;
+      const walkX = x - startX;
+      const walkY = y - startY;
+      outer.scrollLeft = scrollLeft - walkX;
+      outer.scrollTop = scrollTop - walkY;
+    });
+
+    outer.addEventListener('touchmove', (e) => {
+      if (!isDown) return;
+      e.preventDefault();
+      const x = e.touches[0].pageX - outer.offsetLeft;
+      const y = e.touches[0].pageY - outer.offsetTop;
       const walkX = x - startX;
       const walkY = y - startY;
       outer.scrollLeft = scrollLeft - walkX;


### PR DESCRIPTION
## Summary
- add `index2.html` with draggable canvas of project images for exploratory layout
- round images and place them on an evenly spaced grid with slight jitter to keep them close without overlapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1b073e08333b8e9846d01cac791