### PR TITLE
Create Palmer Dinnerware-inspired landing page

### DIFF
--- a/index3.html
+++ b/index3.html
@@ -1,0 +1,840 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Palmer Dinnerware &mdash; Gather Worthy Stoneware</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Manrope:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream: #fbf7f1;
+      --soft-cream: #f4eee7;
+      --espresso: #3f2f26;
+      --terra: #b5723a;
+      --sage: #8f9a81;
+      --linen: #ede5dd;
+      --text: #2b1f19;
+      --muted: rgba(47, 33, 28, 0.62);
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Manrope', 'Segoe UI', sans-serif;
+      color: var(--text);
+      background: var(--cream);
+      line-height: 1.65;
+    }
+
+    img {
+      display: block;
+      max-width: 100%;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    nav {
+      position: sticky;
+      top: 0;
+      background: rgba(253, 250, 245, 0.92);
+      backdrop-filter: blur(12px);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.25rem 6vw;
+      z-index: 1000;
+      border-bottom: 1px solid rgba(47, 33, 28, 0.08);
+    }
+
+    .brand {
+      font-family: 'Playfair Display', serif;
+      font-size: 1.6rem;
+      letter-spacing: 0.25rem;
+      text-transform: uppercase;
+    }
+
+    .brand span {
+      font-weight: 600;
+      letter-spacing: 0.3rem;
+      color: var(--terra);
+    }
+
+    .nav-links {
+      list-style: none;
+      display: flex;
+      gap: 1.75rem;
+      margin: 0;
+      padding: 0;
+      text-transform: uppercase;
+      font-size: 0.82rem;
+      letter-spacing: 0.14em;
+    }
+
+    .nav-links a:hover,
+    .nav-links a:focus {
+      color: var(--terra);
+    }
+
+    .nav-cta {
+      border: 1px solid var(--terra);
+      padding: 0.55rem 1.4rem;
+      border-radius: 2rem;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      transition: background 0.3s ease, color 0.3s ease;
+    }
+
+    .nav-cta:hover,
+    .nav-cta:focus {
+      background: var(--terra);
+      color: #fff;
+    }
+
+    .hero {
+      min-height: 92vh;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: center;
+      gap: 3.5rem;
+      padding: 6rem 6vw 4rem;
+    }
+
+    .hero-copy {
+      max-width: 520px;
+    }
+
+    .eyebrow {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.4em;
+      color: var(--muted);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+    }
+
+    .eyebrow::before {
+      content: "";
+      display: inline-block;
+      width: 42px;
+      height: 1px;
+      background: currentColor;
+    }
+
+    .hero h1 {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(3.2rem, 4.3vw + 1.5rem, 4.8rem);
+      line-height: 1.05;
+      margin: 1.5rem 0 1.25rem;
+      color: var(--espresso);
+    }
+
+    .hero p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      margin-bottom: 2.5rem;
+    }
+
+    .cta-group {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      border-radius: 999px;
+      padding: 0.9rem 1.9rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      font-size: 0.85rem;
+      border: 1px solid transparent;
+      transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease;
+    }
+
+    .btn-primary {
+      background: var(--terra);
+      color: #fff;
+    }
+
+    .btn-primary:hover,
+    .btn-primary:focus {
+      transform: translateY(-2px);
+      background: #a15f2d;
+    }
+
+    .btn-outline {
+      border-color: var(--espresso);
+      color: var(--espresso);
+      background: transparent;
+    }
+
+    .btn-outline:hover,
+    .btn-outline:focus {
+      background: var(--espresso);
+      color: #fff;
+    }
+
+    .hero-visual {
+      position: relative;
+    }
+
+    .hero-visual::before {
+      content: "";
+      position: absolute;
+      inset: 12% -8% -12% -12%;
+      background: var(--linen);
+      border-radius: 32px;
+      z-index: -2;
+    }
+
+    .hero-visual::after {
+      content: "";
+      position: absolute;
+      width: 220px;
+      height: 220px;
+      bottom: -70px;
+      right: -70px;
+      border-radius: 50%;
+      background: rgba(181, 114, 58, 0.18);
+      z-index: -1;
+      filter: blur(0.5px);
+    }
+
+    .hero-image {
+      border-radius: 28px;
+      overflow: hidden;
+      box-shadow: 0 24px 60px rgba(61, 45, 33, 0.18);
+    }
+
+    .hero-image img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .section {
+      padding: 6rem 6vw;
+    }
+
+    .section-header {
+      text-align: center;
+      max-width: 720px;
+      margin: 0 auto 3.5rem;
+    }
+
+    .section-header h2 {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2.4rem, 2.2vw + 1.6rem, 3.4rem);
+      color: var(--espresso);
+      margin-bottom: 1rem;
+    }
+
+    .section-header p {
+      color: var(--muted);
+      font-size: 1rem;
+    }
+
+    .collection-grid {
+      display: grid;
+      gap: 2.25rem;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .collection-card {
+      background: #fff;
+      border-radius: 28px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 0 28px 60px rgba(55, 41, 33, 0.12);
+      transition: transform 0.45s ease, box-shadow 0.45s ease;
+    }
+
+    .collection-card:hover {
+      transform: translateY(-10px);
+      box-shadow: 0 40px 70px rgba(55, 41, 33, 0.18);
+    }
+
+    .collection-content {
+      padding: 2rem 2.25rem 2.5rem;
+    }
+
+    .collection-content h3 {
+      font-family: 'Playfair Display', serif;
+      font-size: 1.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .collection-content p {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .collection-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 1.75rem;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      color: var(--terra);
+    }
+
+    .collection-meta span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+
+    .collection-meta span::after {
+      content: "→";
+      font-size: 0.9rem;
+    }
+
+    .features {
+      background: var(--soft-cream);
+      border-radius: 32px;
+      padding: 4rem 5vw;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 2.5rem;
+    }
+
+    .feature {
+      text-align: center;
+      padding: 0 1rem;
+    }
+
+    .feature-icon {
+      width: 72px;
+      height: 72px;
+      border-radius: 50%;
+      margin: 0 auto 1.25rem;
+      display: grid;
+      place-content: center;
+      background: rgba(181, 114, 58, 0.18);
+      color: var(--terra);
+      font-size: 1.6rem;
+    }
+
+    .feature h4 {
+      font-family: 'Playfair Display', serif;
+      font-size: 1.25rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .feature p {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .story {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 4rem;
+      align-items: center;
+    }
+
+    .story figure {
+      position: relative;
+    }
+
+    .story figure::before {
+      content: "";
+      position: absolute;
+      inset: -8% -10% -12% -5%;
+      border-radius: 40px;
+      background: rgba(143, 154, 129, 0.24);
+      z-index: -1;
+    }
+
+    .story figure img {
+      border-radius: 32px;
+      box-shadow: 0 20px 50px rgba(43, 31, 25, 0.14);
+    }
+
+    .story-content h3 {
+      font-family: 'Playfair Display', serif;
+      font-size: 2.6rem;
+      margin-bottom: 1.5rem;
+      color: var(--espresso);
+    }
+
+    .story-content p {
+      color: var(--muted);
+    }
+
+    .story-content .signature {
+      margin-top: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      font-size: 0.9rem;
+    }
+
+    .journal-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 2.2rem;
+    }
+
+    .journal-card {
+      background: #fff;
+      border-radius: 26px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 0 22px 55px rgba(55, 41, 33, 0.12);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .journal-card:hover {
+      transform: translateY(-8px);
+      box-shadow: 0 34px 70px rgba(55, 41, 33, 0.18);
+    }
+
+    .journal-content {
+      padding: 1.9rem 2.2rem 2.4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+      flex: 1;
+    }
+
+    .journal-tag {
+      font-size: 0.75rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--terra);
+    }
+
+    .journal-content h4 {
+      font-family: 'Playfair Display', serif;
+      font-size: 1.45rem;
+      margin: 0;
+      color: var(--espresso);
+    }
+
+    .journal-content p {
+      color: var(--muted);
+      margin: 0;
+    }
+
+    .journal-link {
+      margin-top: auto;
+      font-size: 0.85rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--terra);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+
+    .journal-link::after {
+      content: "→";
+      font-size: 0.95rem;
+    }
+
+    .newsletter {
+      margin-top: 4rem;
+      background: #fff;
+      border-radius: 38px;
+      padding: 3.5rem clamp(2rem, 6vw, 5rem);
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 3rem;
+      align-items: center;
+      box-shadow: 0 26px 60px rgba(47, 33, 27, 0.12);
+    }
+
+    .newsletter h3 {
+      font-family: 'Playfair Display', serif;
+      font-size: 2.2rem;
+      margin-bottom: 1rem;
+      color: var(--espresso);
+    }
+
+    .newsletter p {
+      color: var(--muted);
+      margin: 0;
+    }
+
+    .newsletter form {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .newsletter input {
+      flex: 1 1 260px;
+      border: 1px solid rgba(47, 33, 28, 0.16);
+      border-radius: 999px;
+      padding: 0.95rem 1.6rem;
+      font-size: 0.95rem;
+      background: var(--soft-cream);
+      font-family: inherit;
+      transition: border 0.3s ease;
+    }
+
+    .newsletter input:focus {
+      outline: none;
+      border-color: var(--terra);
+      background: #fff;
+    }
+
+    footer {
+      margin-top: 6rem;
+      padding: 3rem 6vw 2.2rem;
+      background: #f2e9df;
+    }
+
+    .footer-top {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 3rem;
+      align-items: flex-start;
+    }
+
+    .footer-brand {
+      max-width: 320px;
+    }
+
+    .footer-brand h4 {
+      font-family: 'Playfair Display', serif;
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
+
+    .footer-brand p {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .footer-links {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 2.5rem;
+    }
+
+    .footer-links h5 {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      margin-bottom: 1.2rem;
+    }
+
+    .footer-links ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.6rem;
+    }
+
+    .footer-links a {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .footer-links a:hover,
+    .footer-links a:focus {
+      color: var(--terra);
+    }
+
+    .footer-bottom {
+      margin-top: 3rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: rgba(47, 33, 28, 0.54);
+    }
+
+    @media (max-width: 1180px) {
+      .collection-grid,
+      .journal-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .features {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .newsletter {
+        grid-template-columns: 1fr;
+      }
+
+      .nav-links {
+        display: none;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .hero {
+        grid-template-columns: 1fr;
+        padding-top: 5rem;
+      }
+
+      .hero-visual {
+        order: -1;
+      }
+
+      .story {
+        grid-template-columns: 1fr;
+      }
+
+      .footer-links {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 640px) {
+      nav {
+        padding: 1.1rem 1.6rem;
+      }
+
+      .hero {
+        padding: 5.5rem 1.6rem 3.5rem;
+        gap: 2.5rem;
+      }
+
+      .section {
+        padding: 4.5rem 1.6rem;
+      }
+
+      .collection-grid,
+      .journal-grid,
+      .features {
+        grid-template-columns: 1fr;
+      }
+
+      .footer-links {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="#home" class="brand">Palmer <span>Co.</span></a>
+    <ul class="nav-links">
+      <li><a href="#collections">Collections</a></li>
+      <li><a href="#story">Story</a></li>
+      <li><a href="#journal">Journal</a></li>
+      <li><a href="#newsletter">Newsletter</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+    <a href="#collections" class="nav-cta">Shop Dinnerware</a>
+  </nav>
+
+  <main>
+    <section class="hero" id="home">
+      <div class="hero-copy">
+        <span class="eyebrow">Hand-thrown in small batches</span>
+        <h1>Artfully crafted dinnerware for every gathering.</h1>
+        <p>Palmer Dinnerware pairs the warmth of the table with the durability of stoneware. From sunrise breakfast bowls to candlelit dinners, each piece is designed to be a modern heirloom that is meant to be used every day.</p>
+        <div class="cta-group">
+          <a class="btn btn-primary" href="#collections">Shop the collection</a>
+          <a class="btn btn-outline" href="#journal">View journal</a>
+        </div>
+      </div>
+      <div class="hero-visual">
+        <div class="hero-image">
+          <img src="https://images.unsplash.com/photo-1509474520651-53cf6a805f02?auto=format&fit=crop&w=1100&q=80" alt="Stack of ceramic plates in natural light" loading="lazy">
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="collections">
+      <div class="section-header">
+        <h2>Signature collections</h2>
+        <p>Discover layered palettes, balanced forms, and thoughtful glaze finishes. Mix and match to build the tablescape that feels uniquely yours.</p>
+      </div>
+      <div class="collection-grid">
+        <article class="collection-card">
+          <img src="https://images.unsplash.com/photo-1542785291-06405249e635?auto=format&fit=crop&w=1200&q=80" alt="Neutral toned dinnerware with linen napkin" loading="lazy">
+          <div class="collection-content">
+            <h3>The Hearth Set</h3>
+            <p>Earthy, satin-matte glazes finished with hand-polished rims for an elevated everyday dining experience. Perfect for slow Sunday gatherings and dinner parties alike.</p>
+            <div class="collection-meta"><span>Shop set</span><time datetime="2024">2024</time></div>
+          </div>
+        </article>
+        <article class="collection-card">
+          <img src="https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?auto=format&fit=crop&w=1200&q=80" alt="Stoneware bowls displayed on shelves" loading="lazy">
+          <div class="collection-content">
+            <h3>Open Pantry</h3>
+            <p>Storage-worthy vessels that move gracefully from prep to plating. Each piece is kiln-fired twice to create the durable, chip-resistant finish Palmer is known for.</p>
+            <div class="collection-meta"><span>Build a bundle</span><time datetime="2024">2024</time></div>
+          </div>
+        </article>
+        <article class="collection-card">
+          <img src="https://images.unsplash.com/photo-1528141601621-38b9a45d4ef4?auto=format&fit=crop&w=1200&q=80" alt="Colorful ceramic plates arranged in a stack" loading="lazy">
+          <div class="collection-content">
+            <h3>Palette Series</h3>
+            <p>Soft pastels meet sculpted silhouettes for statement-worthy place settings. Designed to layer seamlessly with the neutrals you already love.</p>
+            <div class="collection-meta"><span>Explore palette</span><time datetime="2024">New</time></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="features">
+        <div class="feature">
+          <div class="feature-icon">⏱</div>
+          <h4>Small batch</h4>
+          <p>Each vessel is wheel-thrown and finished by hand in our Portland studio, ensuring subtle variations that make every place setting one-of-a-kind.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">🔥</div>
+          <h4>Oven &amp; dishwasher safe</h4>
+          <p>Glazed with food-safe, lead-free finishes and fired at over 2200&deg;F for durability that stands up to everyday use.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">🌿</div>
+          <h4>Sustainable clay</h4>
+          <p>We partner with regional clay suppliers and recycle every off-cut back into the production loop to minimize waste.</p>
+        </div>
+        <div class="feature">
+          <div class="feature-icon">🎁</div>
+          <h4>Gifting ready</h4>
+          <p>Every order ships in recyclable packaging with a handwritten care guide&mdash;perfect for newlyweds and new homeowners.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="story">
+      <div class="story">
+        <figure>
+          <img src="https://images.unsplash.com/photo-1600180758890-6dcb8f3d94f9?auto=format&fit=crop&w=1200&q=80" alt="Artisan shaping clay on a pottery wheel" loading="lazy">
+        </figure>
+        <div class="story-content">
+          <h3>Rooted in the rituals of gathering</h3>
+          <p>Founder and ceramicist Naomi Palmer began shaping clay as a way to slow down and savor meals with friends. Today, Palmer Dinnerware is still produced in limited runs, using sustainably sourced stoneware and glazes mixed in-house.</p>
+          <p>Every collection begins with sketches inspired by the changing Pacific Northwest seasons. From there, prototypes are tested at the studio table&mdash;the heart of our design process&mdash;to ensure each piece stacks, serves, and delights.</p>
+          <div class="signature">
+            <strong>Naomi Palmer</strong>
+            <span>Founder &amp; Ceramicist</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="journal">
+      <div class="section-header">
+        <h2>From the journal</h2>
+        <p>Stories about craft, entertaining, and the people who bring Palmer Dinnerware to the table.</p>
+      </div>
+      <div class="journal-grid">
+        <article class="journal-card">
+          <img src="https://images.unsplash.com/photo-1505935428862-770b6f24f629?auto=format&fit=crop&w=1200&q=80" alt="Table setting with candles and ceramics" loading="lazy">
+          <div class="journal-content">
+            <span class="journal-tag">Entertaining</span>
+            <h4>Setting a fall harvest table</h4>
+            <p>Layer tones of burnt sienna with muted greens and taper candles for a gathering that feels both grounded and celebratory.</p>
+            <a class="journal-link" href="#">Read article</a>
+          </div>
+        </article>
+        <article class="journal-card">
+          <img src="https://images.unsplash.com/photo-1498579397066-22750a3cb424?auto=format&fit=crop&w=1200&q=80" alt="Shelves displaying handmade ceramic plates" loading="lazy">
+          <div class="journal-content">
+            <span class="journal-tag">Studio</span>
+            <h4>Inside the glazing room</h4>
+            <p>A look at how our team finishes each vessel by hand, layering glazes to achieve the signature Palmer depth of tone.</p>
+            <a class="journal-link" href="#">Read article</a>
+          </div>
+        </article>
+        <article class="journal-card">
+          <img src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1200&q=80" alt="Friends enjoying dinner with ceramic plates" loading="lazy">
+          <div class="journal-content">
+            <span class="journal-tag">Community</span>
+            <h4>Gather with Palmer: Seattle</h4>
+            <p>We teamed up with local chefs to create an intimate supper celebrating seasonal produce and our latest stoneware palette.</p>
+            <a class="journal-link" href="#">Read article</a>
+          </div>
+        </article>
+      </div>
+
+      <div class="newsletter" id="newsletter">
+        <div>
+          <h3>Join the table newsletter</h3>
+          <p>Be the first to know about kiln openings, limited runs, and studio events. A slow, thoughtful email delivered twice a month.</p>
+        </div>
+        <form action="#" method="post">
+          <label class="sr-only" for="newsletter-email">Email address</label>
+          <input id="newsletter-email" type="email" name="email" placeholder="Email address" required>
+          <button class="btn btn-primary" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer id="contact">
+    <div class="footer-top">
+      <div class="footer-brand">
+        <h4>Palmer Dinnerware</h4>
+        <p>Handcrafted stoneware designed for daily rituals and meaningful gatherings. Visit our Portland showroom Thursday through Sunday or schedule a private studio appointment.</p>
+      </div>
+      <div class="footer-links">
+        <div>
+          <h5>Shop</h5>
+          <ul>
+            <li><a href="#collections">All dinnerware</a></li>
+            <li><a href="#collections">Bundles</a></li>
+            <li><a href="#collections">Gift cards</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>About</h5>
+          <ul>
+            <li><a href="#story">Our story</a></li>
+            <li><a href="#journal">Journal</a></li>
+            <li><a href="#">Sustainability</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Visit</h5>
+          <ul>
+            <li><a href="#contact">Showroom</a></li>
+            <li><a href="mailto:hello@palmer-dinnerware.com">hello@palmer-dinnerware.com</a></li>
+            <li><a href="#">@palmerdinnerware</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <time datetime="2024">2024</time> Palmer Dinnerware. All rights reserved.</span>
+      <span>Crafted in Portland, Oregon.</span>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `index3.html` that recreates the Palmer Dinnerware marketing site structure
- include responsive layout, hero, collection cards, feature highlights, story, journal, and newsletter sections with curated imagery
- style the page with inline CSS using modern typography, color palette, and accessibility tweaks for labels and navigation

## Testing
- No automated tests were run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68c85280b3c08333afe6dac02a490087