### PR TITLE
Add Apple Watch inspired app drawer page

### DIFF
--- a/index3.html
+++ b/index3.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apple Watch Inspired App Drawer</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at top, #1c1c1c, #050505 65%);
+        font-family: "SF Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: #f5f5f5;
+      }
+
+      main {
+        text-align: center;
+        padding: 2rem 1.5rem 3rem;
+      }
+
+      h1 {
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin-bottom: 1.75rem;
+        color: rgba(255, 255, 255, 0.9);
+        text-transform: uppercase;
+        font-size: clamp(1.1rem, 2vw + 0.8rem, 1.75rem);
+      }
+
+      .app-drawer {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        align-items: center;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1.5rem;
+      }
+
+      .row.offset {
+        transform: translateX(3.4rem);
+      }
+
+      .app-icon {
+        width: clamp(56px, 8vw, 74px);
+        aspect-ratio: 1 / 1;
+        border-radius: 50%;
+        overflow: hidden;
+        backdrop-filter: blur(6px);
+        background: linear-gradient(145deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.35));
+        box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        display: grid;
+        place-items: center;
+        transition: transform 0.25s ease, box-shadow 0.25s ease;
+      }
+
+      .app-icon img {
+        width: 80%;
+        height: 80%;
+        object-fit: contain;
+        filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.25));
+      }
+
+      .app-icon.center {
+        width: clamp(66px, 9vw, 86px);
+      }
+
+      .app-icon:hover {
+        transform: translateY(-8px) scale(1.05);
+        box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+      }
+
+      @media (max-width: 768px) {
+        .row.offset {
+          transform: translateX(1.8rem);
+        }
+      }
+
+      @media (max-width: 520px) {
+        body {
+          padding: 2rem 0.5rem;
+        }
+
+        .app-drawer {
+          gap: 1.2rem;
+        }
+
+        .row {
+          gap: 1.2rem;
+        }
+
+        .row.offset {
+          transform: translateX(1rem);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Apple Watch Style App Drawer</h1>
+      <div class="app-drawer" aria-label="Application icons">
+        <div class="row">
+          <div class="app-icon"><img src="images/arr.png" alt="ARR Project" /></div>
+          <div class="app-icon"><img src="images/CAcover.png" alt="CA Cover" /></div>
+          <div class="app-icon"><img src="images/dfw.png" alt="DFW" /></div>
+          <div class="app-icon"><img src="images/gro247dls.png" alt="Gro247" /></div>
+          <div class="app-icon"><img src="images/mb.png" alt="MB" /></div>
+        </div>
+        <div class="row offset">
+          <div class="app-icon"><img src="images/pd.png" alt="Product Design" /></div>
+          <div class="app-icon"><img src="images/elm.png" alt="ELM" /></div>
+          <div class="app-icon center"><img src="images/hp.png" alt="HP" /></div>
+          <div class="app-icon"><img src="images/qz.png" alt="Quiz" /></div>
+          <div class="app-icon"><img src="images/zcs.png" alt="ZCS" /></div>
+        </div>
+        <div class="row">
+          <div class="app-icon"><img src="images/sol.png" alt="SOL" /></div>
+          <div class="app-icon"><img src="images/sos.png" alt="SOS" /></div>
+          <div class="app-icon center"><img src="images/sp.png" alt="SP" /></div>
+          <div class="app-icon"><img src="images/ttd.png" alt="TTD" /></div>
+          <div class="app-icon"><img src="images/ubercover.png" alt="Uber" /></div>
+        </div>
+        <div class="row offset">
+          <div class="app-icon"><img src="images/usmile.png" alt="U Smile" /></div>
+          <div class="app-icon"><img src="images/kv.png" alt="KV" /></div>
+          <div class="app-icon"><img src="images/ck.png" alt="CK" /></div>
+          <div class="app-icon center"><img src="images/caarg.png" alt="CA ARG" /></div>
+          <div class="app-icon"><img src="images/dadshsg.png" alt="Dadsh SG" /></div>
+        </div>
+        <div class="row">
+          <div class="app-icon"><img src="images/as.png" alt="AS" /></div>
+          <div class="app-icon"><img src="images/bkwai.png" alt="BKW AI" /></div>
+          <div class="app-icon"><img src="images/kv.png" alt="KV" /></div>
+          <div class="app-icon"><img src="images/qachecklist.png" alt="QA Checklist" /></div>
+          <div class="app-icon"><img src="images/tl.png" alt="TL" /></div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `index3.html` page showcasing an Apple Watch inspired app drawer layout
- implement responsive styling and hover effects for circular app icons arranged in offset rows

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9a676caa8833380c47703e2c60a9e