### PR TITLE
Expand app drawer icons and add cursor follow animation

### DIFF
--- a/index3.html
+++ b/index3.html
@@ -57,32 +57,39 @@
       }
 
       .app-icon {
-        width: clamp(56px, 8vw, 74px);
+        width: clamp(90px, 11vw, 132px);
         aspect-ratio: 1 / 1;
         border-radius: 50%;
         overflow: hidden;
         backdrop-filter: blur(6px);
         background: linear-gradient(145deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.35));
-        box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
         display: grid;
         place-items: center;
+        --offset-x: 0px;
+        --offset-y: 0px;
+        --hover-scale: 1;
+        --hover-lift: 0px;
         transition: transform 0.25s ease, box-shadow 0.25s ease;
+        transform: translate3d(var(--offset-x), calc(var(--offset-y) + var(--hover-lift)), 0)
+          scale(var(--hover-scale));
       }
 
       .app-icon img {
-        width: 80%;
-        height: 80%;
-        object-fit: contain;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
         filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.25));
       }
 
       .app-icon.center {
-        width: clamp(66px, 9vw, 86px);
+        width: clamp(104px, 13vw, 152px);
       }
 
       .app-icon:hover {
-        transform: translateY(-8px) scale(1.05);
-        box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+        --hover-scale: 1.07;
+        --hover-lift: -12px;
+        box-shadow: 0 18px 34px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
       }
 
       @media (max-width: 768px) {
@@ -151,5 +158,33 @@
         </div>
       </div>
     </main>
+    <script>
+      const icons = document.querySelectorAll(".app-icon");
+      const maxShift = 20;
+
+      const updateIconOffset = (clientX, clientY) => {
+        const xRatio = clientX / window.innerWidth - 0.5;
+        const yRatio = clientY / window.innerHeight - 0.5;
+        const offsetX = xRatio * maxShift;
+        const offsetY = yRatio * maxShift;
+
+        icons.forEach((icon, index) => {
+          const depth = 0.4 + (index % 5) * 0.12;
+          icon.style.setProperty("--offset-x", `${offsetX * depth}px`);
+          icon.style.setProperty("--offset-y", `${offsetY * depth}px`);
+        });
+      };
+
+      window.addEventListener("pointermove", (event) => {
+        updateIconOffset(event.clientX, event.clientY);
+      });
+
+      window.addEventListener("pointerleave", () => {
+        icons.forEach((icon) => {
+          icon.style.setProperty("--offset-x", "0px");
+          icon.style.setProperty("--offset-y", "0px");
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enlarge the circular app icons and adjust their styling so thumbnails fill the container cleanly
- update hover handling to use CSS variables, keeping the lift/scale effect compatible with scripted offsets
- add a pointer-tracking script that nudges icons toward the cursor for a subtle follow interaction

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cadf3fc1c48333b784ae457d8dc659